### PR TITLE
feat: Add a direct-canvas route

### DIFF
--- a/src/direct-canvas/App.tsx
+++ b/src/direct-canvas/App.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from "react";
+import Doom from "../doom/Doom";
+
+const width = 320;
+const height = 200;
+const pixelSize = 4;
+
+function App() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(function initDoom() {
+    const doom = new Doom((imageData) => {
+      const canvas = canvasRef.current;
+      if (canvas == null) {
+        return;
+      }
+      const ctx = canvas.getContext("2d");
+      if (ctx == null) {
+        return;
+      }
+      // Do it square by square like we would in a grid
+      // Obviously doing a ctx.putImageData(imageData, 0, 0) would be faster, but we're trying to simulate a grid
+      // ctx.putImageData(imageData, 0, 0);
+      const { data } = imageData;
+      const scale = imageData.width / width;
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          const colorIndex = (y * imageData.width * scale + x * scale) * 4;
+          const r = data[colorIndex];
+          const g = data[colorIndex + 1];
+          const b = data[colorIndex + 2];
+          ctx.fillStyle = `rgb(${r},${g},${b})`;
+          ctx.fillRect(x * pixelSize, y * pixelSize, pixelSize, pixelSize);
+        }
+      }
+    });
+    doom.start();
+    window.addEventListener("keydown", doom.keyDown);
+    window.addEventListener("keyup", doom.keyUp);
+    return () => {
+      doom.stop();
+      window.removeEventListener("keydown", doom.keyDown);
+      window.removeEventListener("keyup", doom.keyUp);
+    };
+  }, []);
+
+  return (
+    <>
+      <div
+        style={{
+          width: width * pixelSize,
+          height: height * pixelSize,
+          position: "relative",
+        }}
+      >
+        <canvas
+          width={width * pixelSize}
+          height={height * pixelSize}
+          ref={canvasRef}
+        />
+      </div>
+    </>
+  );
+}
+
+export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import DeephavenApp from "./deephaven-grid/App.tsx";
 import AgGridApp from "./ag-grid/App.tsx";
 import GlideGridApp from "./glide-grid/App.tsx";
 import RegularTableApp from "./regular-table/App.tsx";
+import DirectCanvasApp from "./direct-canvas/App.tsx";
 
 import "./index.css";
 
@@ -25,6 +26,10 @@ const router = createBrowserRouter([
   {
     path: "/regular-table",
     element: <RegularTableApp />,
+  },
+  {
+    path: "/direct-canvas",
+    element: <DirectCanvasApp />,
   },
 ]);
 

--- a/src/regular-table/App.tsx
+++ b/src/regular-table/App.tsx
@@ -12,7 +12,6 @@ const pixelSize = 10;
 function App() {
   const tableRef = useRef<RegularTableElement | null>(null);
   const imageDataRef = useRef<ImageData | null>(null);
-  const animationFrameRef = useRef<number | null>(null);
   // It's so slow, we need to skip frames
   const nextRenderTime = useRef<number>(0);
   const setRegularTable = useCallback(


### PR DESCRIPTION
- Renders directly to a canvas, drawing each square like a grid would
- Just to benchmark how fast it would be drawing directly to canvas without any other grid overhead
- Similar performance to deephaven-grid
